### PR TITLE
filter binarized page image

### DIFF
--- a/ocrd_vandalize/processor.py
+++ b/ocrd_vandalize/processor.py
@@ -64,7 +64,7 @@ class OcrdVandalize(Processor):
             log.info('Processing: %d / %s of %d', n, page_id, len(list(self.input_files)))
             pcgts = page_from_file(self.workspace.download_file(input_file))
             page = pcgts.get_Page()
-            pil_image, page_xywh, _ = self.workspace.image_from_page(page, page_id)
+            pil_image, page_xywh, _ = self.workspace.image_from_page(page, page_id, feature_filter='binarized')
             file_id = make_file_id(input_file, self.output_file_grp)
 
             # Watermark the image and add as an AlternativeImage


### PR DESCRIPTION
Apparently forgot to commit this. Without it, it will watermark the binarized image, not the original image - is there another way to specify "choose the original image" I am not thinking of?